### PR TITLE
Fix Gemini API key handling for Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ View your app in AI Studio: https://ai.studio/apps/drive/1UEt0ap-0kQPwTD-hZVxubY
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Create a `.env.local` file and add your Gemini API key as `VITE_GEMINI_API_KEY="your-key"`
 3. Run the app:
    `npm run dev`

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -2,11 +2,21 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import type { CatBreedAnalysis } from '../types';
 
-if (!process.env.API_KEY) {
-  throw new Error("API_KEY environment variable not set");
-}
+const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
 
-const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+let aiClient: GoogleGenAI | null = null;
+
+const getClient = () => {
+  if (!apiKey) {
+    throw new Error('Gemini API key is not configured. Please set the VITE_GEMINI_API_KEY environment variable.');
+  }
+
+  if (!aiClient) {
+    aiClient = new GoogleGenAI({ apiKey });
+  }
+
+  return aiClient;
+};
 
 const model = 'gemini-2.5-flash';
 
@@ -54,7 +64,9 @@ export const identifyCatBreed = async (base64Image: string, mimeType: string): P
   };
   
   try {
-    const response = await ai.models.generateContent({
+    const client = getClient();
+
+    const response = await client.models.generateContent({
       model: model,
       contents: { parts: [textPart, imagePart] },
       config: {

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+
+declare global {
+  interface ImportMetaEnv {
+    readonly VITE_GEMINI_API_KEY?: string;
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- read the Gemini API key from Vite environment variables and lazily create the client
- add TypeScript definitions for the new environment variable
- document the VITE_GEMINI_API_KEY setup in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1826d0ad8832c85c11680763180ad