### PR TITLE
Support Auth0 build arguments

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,9 +12,13 @@
     # Copy the rest of the project (remember: you're in src/)
     COPY . .
     
-    # (Hackathon OK; exposes key in built JS)
-    ARG VITE_GEMINI_API_KEY
-    ENV VITE_GEMINI_API_KEY=$VITE_GEMINI_API_KEY
+# (Hackathon OK; exposes key in built JS)
+ARG VITE_GEMINI_API_KEY
+ARG VITE_AUTH0_DOMAIN
+ARG VITE_AUTH0_CLIENT_ID
+ENV VITE_GEMINI_API_KEY=$VITE_GEMINI_API_KEY \
+    VITE_AUTH0_DOMAIN=$VITE_AUTH0_DOMAIN \
+    VITE_AUTH0_CLIENT_ID=$VITE_AUTH0_CLIENT_ID
     
     # Build Vite app -> /app/dist
     RUN npm run build

--- a/src/cloudbuild.yaml
+++ b/src/cloudbuild.yaml
@@ -28,6 +28,20 @@ steps:
         exit 1
       fi
       echo "Secret fetched OK."
+      if ! gcloud secrets versions access latest --secret=VITE_AUTH0_DOMAIN > /workspace/.auth0domain ; then
+        echo "FAILED to read VITE_AUTH0_DOMAIN. IAM or API issue." >&2
+        gcloud secrets get-iam-policy VITE_AUTH0_DOMAIN --format='yaml' || true
+        gcloud info || true
+        exit 1
+      fi
+      echo "Auth0 domain secret fetched OK."
+      if ! gcloud secrets versions access latest --secret=VITE_AUTH0_CLIENT_ID > /workspace/.auth0clientid ; then
+        echo "FAILED to read VITE_AUTH0_CLIENT_ID. IAM or API issue." >&2
+        gcloud secrets get-iam-policy VITE_AUTH0_CLIENT_ID --format='yaml' || true
+        gcloud info || true
+        exit 1
+      fi
+      echo "Auth0 client ID secret fetched OK."
 
 # 2) Build the Docker image (tag with BUILD_ID and latest)
 - name: gcr.io/cloud-builders/docker
@@ -40,6 +54,8 @@ steps:
       IMG="${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE_NAME}"
       docker build \
         --build-arg VITE_GEMINI_API_KEY="$$(cat /workspace/.geminikey)" \
+        --build-arg VITE_AUTH0_DOMAIN="$$(cat /workspace/.auth0domain)" \
+        --build-arg VITE_AUTH0_CLIENT_ID="$$(cat /workspace/.auth0clientid)" \
         -t "$${IMG}:$BUILD_ID" \
         -t "$${IMG}:latest" \
         .

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -5,9 +5,12 @@ REGION=us-south1
 SERVICE=meowtion-sensor
 
 gcloud config set project "$PROJECT"
+GEMINI_KEY=$(gcloud secrets versions access latest --secret=VITE_GEMINI_API_KEY)
+AUTH0_DOMAIN=$(gcloud secrets versions access latest --secret=VITE_AUTH0_DOMAIN)
+AUTH0_CLIENT_ID=$(gcloud secrets versions access latest --secret=VITE_AUTH0_CLIENT_ID)
 gcloud run deploy "$SERVICE" \
   --source . \
   --region "$REGION" \
   --allow-unauthenticated \
-  --set-build-env-vars VITE_GEMINI_API_KEY="$(gcloud secrets versions access latest --secret=VITE_GEMINI_API_KEY)"
+  --set-build-env-vars "VITE_GEMINI_API_KEY=${GEMINI_KEY},VITE_AUTH0_DOMAIN=${AUTH0_DOMAIN},VITE_AUTH0_CLIENT_ID=${AUTH0_CLIENT_ID}"
 


### PR DESCRIPTION
## Summary
- expose Auth0 domain and client ID as Docker build arguments and environment variables for the Vite build
- fetch the Auth0 secrets in Cloud Build and forward them as build arguments during the image build
- update the manual Cloud Run deployment script to supply the Auth0 build-time variables from Secret Manager

## Testing
- not run (infrastructure commands not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e222ecce38832c8d3f95d265e5f7a1