### PR TITLE
Handle missing Auth0 configuration gracefully

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,19 +15,33 @@ const domain = import.meta.env.VITE_AUTH0_DOMAIN;
 const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
 
 if (!domain || !clientId) {
-  throw new Error('Missing Auth0 configuration. Please set VITE_AUTH0_DOMAIN and VITE_AUTH0_CLIENT_ID in your environment.');
-}
+  console.error(
+    'Missing Auth0 configuration. Please set VITE_AUTH0_DOMAIN and VITE_AUTH0_CLIENT_ID in your environment.'
+  );
 
-root.render(
-  <React.StrictMode>
-    <Auth0Provider
-      domain={domain}
-      clientId={clientId}
-      authorizationParams={{
-        redirect_uri: window.location.origin,
-      }}
-    >
-      <App />
-    </Auth0Provider>
-  </React.StrictMode>
-);
+  root.render(
+    <React.StrictMode>
+      <div style={{ padding: '2rem', fontFamily: 'sans-serif', textAlign: 'center' }}>
+        <h1>Configuration Error</h1>
+        <p>
+          The application could not start because the required Auth0 environment variables are not set.
+          Please configure <code>VITE_AUTH0_DOMAIN</code> and <code>VITE_AUTH0_CLIENT_ID</code>.
+        </p>
+      </div>
+    </React.StrictMode>
+  );
+} else {
+  root.render(
+    <React.StrictMode>
+      <Auth0Provider
+        domain={domain}
+        clientId={clientId}
+        authorizationParams={{
+          redirect_uri: window.location.origin,
+        }}
+      >
+        <App />
+      </Auth0Provider>
+    </React.StrictMode>
+  );
+}


### PR DESCRIPTION
## Summary
- render a clear configuration error page when Auth0 environment variables are absent
- avoid crashing the client bootstrap so deployments without Auth0 config no longer show a blank screen

## Testing
- npm run build *(fails: repository does not include a root package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e254247270832cadf294b1bbebd110