### PR TITLE
Fix Cloud Run deployment env propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,27 @@ View your app in AI Studio: https://ai.studio/apps/drive/1UEt0ap-0kQPwTD-hZVxubY
 3. Run the servers:
    - Start the Gemini proxy API: `npm run server`
    - Start the Vite dev server (in a separate terminal): `npm run dev`
+
+## Deploy to Cloud Run
+
+The repository includes two deployment flows (a helper script and a Cloud Build pipeline). Both expect the same configuration:
+
+- `VITE_GEMINI_API_KEY`
+- `VITE_AUTH0_DOMAIN`
+- `VITE_AUTH0_CLIENT_ID`
+
+### One-command deploy (`src/deploy.sh`)
+
+1. Create an `.env` file **either** in the repository root **or** inside `src/` with the three variables above. The script will automatically pick whichever file exists.
+2. Run `bash src/deploy.sh`. The script sources your `.env`, validates the variables, forwards them to the Cloud Build step with `--build-arg`, and sets the same values on the Cloud Run service for the runtime Gemini proxy.
+
+If you keep secrets in `src/.env`, remember to add it to your local `.gitignore` so you do not commit credentials.
+
+### Cloud Build pipeline (`src/cloudbuild.yaml`)
+
+The provided pipeline accepts two additional substitutions so Auth0 settings make it into the production bundle:
+
+- `_VITE_AUTH0_DOMAIN`
+- `_VITE_AUTH0_CLIENT_ID`
+
+Set them when you create the trigger (alongside the existing `_REGION`, `_REPO`, `_IMAGE_NAME`, and secret for `VITE_GEMINI_API_KEY`). The pipeline passes these substitutions to `docker build --build-arg ...` and configures the Cloud Run service with the same runtime variables.

--- a/src/cloudbuild.yaml
+++ b/src/cloudbuild.yaml
@@ -3,6 +3,8 @@ substitutions:
   _REGION: "us-south1"
   _REPO: "cloud-run-source-deploy"
   _IMAGE_NAME: "meowtion-sensor"
+  _VITE_AUTH0_DOMAIN: ""
+  _VITE_AUTH0_CLIENT_ID: ""
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -40,6 +42,8 @@ steps:
       IMG="${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE_NAME}"
       docker build \
         --build-arg VITE_GEMINI_API_KEY="$$(cat /workspace/.geminikey)" \
+        --build-arg VITE_AUTH0_DOMAIN="${_VITE_AUTH0_DOMAIN}" \
+        --build-arg VITE_AUTH0_CLIENT_ID="${_VITE_AUTH0_CLIENT_ID}" \
         -t "$${IMG}:$BUILD_ID" \
         -t "$${IMG}:latest" \
         .
@@ -69,6 +73,8 @@ steps:
     - --region
     - ${_REGION}
     - --allow-unauthenticated
+    - --set-env-vars
+    - GEMINI_API_KEY=$$(cat /workspace/.geminikey),VITE_AUTH0_DOMAIN=${_VITE_AUTH0_DOMAIN},VITE_AUTH0_CLIENT_ID=${_VITE_AUTH0_CLIENT_ID}
 
 images:
 - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE_NAME}:$BUILD_ID

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -3,9 +3,24 @@
 
 set -e
 
-# Load .env variables from src/.env
+# Resolve repo root (script lives in repo/src)
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Load environment variables from either src/.env or repo-root/.env
+ENV_FILE=""
+if [ -f "${REPO_ROOT}/src/.env" ]; then
+  ENV_FILE="${REPO_ROOT}/src/.env"
+elif [ -f "${REPO_ROOT}/.env" ]; then
+  ENV_FILE="${REPO_ROOT}/.env"
+fi
+
+if [ -z "$ENV_FILE" ]; then
+  echo "❌ Could not find an .env file in src/.env or .env"
+  exit 1
+fi
+
 set -a
-. src/.env
+. "$ENV_FILE"
 set +a
 
 # Verify critical env vars exist
@@ -19,5 +34,7 @@ gcloud run deploy meowtion-sensor \
   --source src \
   --region us-south1 \
   --allow-unauthenticated \
-  --set-build-env-vars="VITE_GEMINI_API_KEY=${VITE_GEMINI_API_KEY},VITE_AUTH0_DOMAIN=${VITE_AUTH0_DOMAIN},VITE_AUTH0_CLIENT_ID=${VITE_AUTH0_CLIENT_ID}" \
+  --build-arg VITE_GEMINI_API_KEY="${VITE_GEMINI_API_KEY}" \
+  --build-arg VITE_AUTH0_DOMAIN="${VITE_AUTH0_DOMAIN}" \
+  --build-arg VITE_AUTH0_CLIENT_ID="${VITE_AUTH0_CLIENT_ID}" \
   --set-env-vars="GEMINI_API_KEY=${VITE_GEMINI_API_KEY},VITE_AUTH0_DOMAIN=${VITE_AUTH0_DOMAIN},VITE_AUTH0_CLIENT_ID=${VITE_AUTH0_CLIENT_ID}"


### PR DESCRIPTION
## Summary
- update the helper deploy script to read an .env file from src/ or the repo root and forward Auth0 settings as Docker build arguments
- extend the Cloud Build pipeline to pass the Auth0 variables during docker build and configure them on the Cloud Run service
- document the Cloud Run deployment expectations and new substitutions in the README

## Testing
- not run (deployment scripting change)


------
https://chatgpt.com/codex/tasks/task_e_68e259179920832c9877c4da50481102