### PR TITLE
Improve accuracy of Gemini cat matching workflow

### DIFF
--- a/src/components/MatchResultCard.tsx
+++ b/src/components/MatchResultCard.tsx
@@ -9,6 +9,7 @@ interface MatchResultCardProps {
 
 const MatchResultCard: React.FC<MatchResultCardProps> = ({ result }) => {
   const confidencePercent = (result.confidence * 100).toFixed(0);
+  const detailedEvaluations = result.evaluations ?? [];
 
   return (
     <div className="mt-6 w-full bg-[#E9DDCD] rounded-xl shadow-lg overflow-hidden animate-fade-in">
@@ -31,6 +32,45 @@ const MatchResultCard: React.FC<MatchResultCardProps> = ({ result }) => {
           <p className="font-semibold text-sm opacity-75">AI's Reasoning</p>
           <p className="text-md italic">"{result.reasoning}"</p>
         </div>
+
+        {detailedEvaluations.length > 0 && (
+          <div className="mt-6">
+            <p className="font-semibold text-sm opacity-75">Detailed comparison</p>
+            <div className="mt-3 space-y-3">
+              {detailedEvaluations.slice(0, 3).map((evaluation, index) => (
+                <div key={`${evaluation.catName}-${index}`} className="bg-white/60 rounded-lg p-3 shadow-sm">
+                  <div className="flex justify-between items-center">
+                    <p className="font-semibold text-[#4a2b18]">{evaluation.catName}</p>
+                    <p className="text-sm font-medium text-[#4a2b18]">
+                      {(evaluation.similarity * 100).toFixed(0)}%
+                    </p>
+                  </div>
+                  <p className="mt-2 text-sm text-[#4a2b18]">{evaluation.summary}</p>
+                  {evaluation.matchedFeatures.length > 0 && (
+                    <div className="mt-2">
+                      <p className="text-xs font-semibold uppercase text-[#4a2b18]/70">Matched features</p>
+                      <ul className="list-disc list-inside text-xs text-[#4a2b18]">
+                        {evaluation.matchedFeatures.map((feature, featureIndex) => (
+                          <li key={`match-${evaluation.catName}-${featureIndex}`}>{feature}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {evaluation.mismatchedFeatures.length > 0 && (
+                    <div className="mt-2">
+                      <p className="text-xs font-semibold uppercase text-[#4a2b18]/70">Conflicting features</p>
+                      <ul className="list-disc list-inside text-xs text-[#4a2b18]">
+                        {evaluation.mismatchedFeatures.map((feature, featureIndex) => (
+                          <li key={`mismatch-${evaluation.catName}-${featureIndex}`}>{feature}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,3 +5,19 @@ export interface CatBreedAnalysis {
   confidence: number;
   description: string;
 }
+
+export interface MatchCandidateEvaluation {
+  catName: string;
+  similarity: number;
+  matchedFeatures: string[];
+  mismatchedFeatures: string[];
+  summary: string;
+}
+
+export interface MatchResult {
+  isMatch: boolean;
+  matchedCatName: string;
+  confidence: number;
+  reasoning: string;
+  evaluations: MatchCandidateEvaluation[];
+}


### PR DESCRIPTION
## Summary
- evaluate each known cat with its own Gemini comparison request and enforce feature-level reasoning
- clamp similarity scores, determine matches with stricter thresholds, and expose per-cat evaluation details
- surface the structured comparison data in the match result card for improved transparency

## Testing
- `npm run build --prefix src` *(fails: Rollup could not resolve @auth0/auth0-react)*

------
https://chatgpt.com/codex/tasks/task_e_68e242747908832cbf5a5a711c6bfcad