### PR TITLE
Add soft green borders to search gallery images

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -422,9 +422,18 @@ const App: React.FC = () => {
           {activeTab === 'search' && (
             <div className="grid grid-cols-3 gap-1 w-full px-1">
               {displayedCats.map((cat, index) => (
-                <div key={`${cat.src}-${index}`} className="aspect-square cursor-pointer" onClick={() => setSelectedImage(cat.src)}>
-                  <img src={cat.src} alt={`${cat.name} ${index + 1}`} className="w-full h-full object-cover" />
-                </div>
+                <button
+                  type="button"
+                  key={`${cat.src}-${index}`}
+                  className="aspect-square cursor-pointer border border-[#4F7057] rounded-lg overflow-hidden transition-transform duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4F7057]/60"
+                  onClick={() => setSelectedImage(cat.src)}
+                >
+                  <img
+                    src={cat.src}
+                    alt={`${cat.name} ${index + 1}`}
+                    className="w-full h-full object-cover"
+                  />
+                </button>
               ))}
             </div>
           )}


### PR DESCRIPTION
## Summary
- add a soft dark-green border around each cat thumbnail in the search grid
- render thumbnails as focusable buttons with non-zoomed borders while preserving the zoom overlay

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: missing optional dependency @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68e29b0f332c832cb7696d96d642a8a1