### PR TITLE
Add client-side post creation workflow

### DIFF
--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -1,0 +1,105 @@
+import type { CreatePostInput, Post } from '../types';
+
+const STORAGE_KEY = 'meowtion-sensor-posts';
+const apiUrl = import.meta.env.VITE_POSTS_API_URL;
+
+const isBrowser = typeof window !== 'undefined';
+
+const loadLocalPosts = (): Post[] => {
+  if (!isBrowser) {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as Post[];
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+    return [];
+  } catch (error) {
+    console.warn('Failed to parse posts from localStorage.', error);
+    return [];
+  }
+};
+
+const saveLocalPosts = (posts: Post[]) => {
+  if (!isBrowser) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+  } catch (error) {
+    console.warn('Unable to persist posts to localStorage.', error);
+  }
+};
+
+export const fetchPosts = async (): Promise<Post[]> => {
+  if (apiUrl) {
+    try {
+      const response = await fetch(apiUrl, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch posts from API. Status: ${response.status}`);
+      }
+      const data = await response.json();
+      if (Array.isArray(data)) {
+        return data as Post[];
+      }
+      console.warn('Unexpected payload when fetching posts, falling back to local storage.');
+    } catch (error) {
+      console.warn('Error retrieving posts from API, falling back to local storage.', error);
+    }
+  }
+  return loadLocalPosts();
+};
+
+export const createPost = async (input: CreatePostInput): Promise<Post> => {
+  if (apiUrl) {
+    try {
+      const response = await fetch(apiUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to create post via API. Status: ${response.status}`);
+      }
+      const data = (await response.json()) as Post;
+      return data;
+    } catch (error) {
+      console.warn('Error creating post via API, storing locally instead.', error);
+    }
+  }
+
+  const currentPosts = loadLocalPosts();
+  const newPost: Post = {
+    id: input.id ?? `local-${Date.now()}`,
+    user: input.user,
+    userAvatar: input.userAvatar,
+    imageUrl: input.imageUrl,
+    caption: input.caption,
+    createdAt: new Date().toISOString(),
+    likes: input.likes ?? 0,
+    catName: input.catName ?? null,
+    hashtags: input.hashtags ?? [],
+    analysisSummary: input.analysisSummary ?? null,
+    matchSummary: input.matchSummary ?? null,
+    aiConfidence: input.aiConfidence ?? null,
+  };
+
+  const updatedPosts = [newPost, ...currentPosts];
+  saveLocalPosts(updatedPosts);
+  return newPost;
+};
+
+export const clearLocalPosts = () => {
+  if (!isBrowser) {
+    return;
+  }
+  window.localStorage.removeItem(STORAGE_KEY);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,3 +21,32 @@ export interface MatchResult {
   reasoning: string;
   evaluations: MatchCandidateEvaluation[];
 }
+
+export interface Post {
+  id: string;
+  user: string;
+  userAvatar: string;
+  imageUrl: string;
+  caption: string;
+  createdAt: string;
+  likes: number;
+  catName?: string | null;
+  hashtags?: string[];
+  analysisSummary?: string | null;
+  matchSummary?: string | null;
+  aiConfidence?: number | null;
+}
+
+export interface CreatePostInput {
+  id?: string;
+  user: string;
+  userAvatar: string;
+  imageUrl: string;
+  caption: string;
+  likes?: number;
+  catName?: string | null;
+  hashtags?: string[];
+  analysisSummary?: string | null;
+  matchSummary?: string | null;
+  aiConfidence?: number | null;
+}


### PR DESCRIPTION
## Summary
- add a post data model and client post service with optional API integration and localStorage fallback
- load stored posts into the feed and expose a handleSubmitPost flow that publishes AI-verified uploads
- refresh the home and add-cat views to surface dynamic post data, validation, and helper messaging

## Testing
- npm run build *(fails: Could not resolve "../assets/catPing.png" from "components/CatMap.tsx")*


------
https://chatgpt.com/codex/tasks/task_e_68e29b95bc24832c95dae94d785518f7