### PR TITLE
Use Comic Sans as the global UI font

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,14 @@
         padding-bottom: env(safe-area-inset-bottom);
         padding-left: env(safe-area-inset-left);
         padding-right: env(safe-area-inset-right);
+        font-family: 'Comic Sans MS', 'Comic Sans', cursive;
+      }
+
+      input,
+      button,
+      textarea,
+      select {
+        font-family: inherit;
       }
     </style>
   </head>

--- a/src/index.html
+++ b/src/index.html
@@ -15,6 +15,14 @@
         padding-bottom: env(safe-area-inset-bottom);
         padding-left: env(safe-area-inset-left);
         padding-right: env(safe-area-inset-right);
+        font-family: 'Comic Sans MS', 'Comic Sans', cursive;
+      }
+
+      input,
+      button,
+      textarea,
+      select {
+        font-family: inherit;
       }
     </style>
   <script type="importmap">
@@ -33,3 +41,4 @@
     <script type="module" src="/index.tsx"></script>
   </body>
 </html>
+


### PR DESCRIPTION
## Summary
- set the default font family to Comic Sans on both HTML entrypoints so the UI uses the new typeface

## Testing
- npm --prefix src run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a1c0c910832c8d7219138be3033b